### PR TITLE
explicitly set docker platform to linux/amd64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ run: ## Run Server
 build-docker: docker-build
 
 docker-build:
-	docker build -t godbledger-web:$(VERSION) -t godbledger-web:latest -f ./utils/Dockerfile.build-web .
+	docker build --platform linux/amd64 -t godbledger-web:$(VERSION) -t godbledger-web:latest -f ./utils/Dockerfile.build-web .
 
 docker-login:
 	@$(if $(strip $(shell docker ps | grep godbledger-web)), @docker exec -it godbledger-web /bin/ash || 0, @docker run -it --rm --entrypoint /bin/ash godbledger-web:$(VERSION) )

--- a/utils/Dockerfile.build-web
+++ b/utils/Dockerfile.build-web
@@ -1,4 +1,4 @@
-FROM golang:1.15.5-alpine AS builder
+FROM --platform=linux/amd64 golang:1.15.5-alpine AS builder
 # https://megamorf.gitlab.io/2019/09/08/alpine-go-builds-with-cgo-enabled/
 
 RUN apk update
@@ -12,7 +12,7 @@ ADD . .
 # TODO: pull app version from VERSION
 RUN make
 
-FROM alpine
+FROM --platform=linux/amd64 alpine
 
 # netcat is needed by wait-for
 RUN apk add net-tools


### PR DESCRIPTION
for compatibility with docker-desktop on `darwin/arm64` hosts

tested on:
- 2015 MacBook Pro (`darwin/amd64`) / Docker Desktop `4.2.0`
- 2021 M1 MacBook Pro (`darwin/arm64`) / Docker Desktop `4.4.2`